### PR TITLE
Fix ESPTime namespace in ht16kk33_alpha

### DIFF
--- a/components/ht16k33_alpha/ht16k33_display.cpp
+++ b/components/ht16k33_alpha/ht16k33_display.cpp
@@ -136,7 +136,7 @@ void HT16K33AlphaDisplay::printf(const char *format, ...) {
 }
 
 #ifdef USE_TIME
-void HT16K33AlphaDisplay::strftime(const char *format, time::ESPTime time) {
+void HT16K33AlphaDisplay::strftime(const char *format, ESPTime time) {
   char buffer[64];
   size_t ret = time.strftime(buffer, sizeof(buffer), format);
   if (ret > 0)

--- a/components/ht16k33_alpha/ht16k33_display.h
+++ b/components/ht16k33_alpha/ht16k33_display.h
@@ -6,6 +6,7 @@
 
 #ifdef USE_TIME
 #include "esphome/components/time/real_time_clock.h"
+#include "esphome/core/time.h"
 #endif
 
 namespace esphome {
@@ -36,7 +37,7 @@ class HT16K33AlphaDisplay : public PollingComponent, public i2c::I2CDevice {
 
 #ifdef USE_TIME
   /// Evaluate the strftime-format and print the text
-  void strftime(const char *format, time::ESPTime time) __attribute__((format(strftime, 2, 0)));
+  void strftime(const char *format, ESPTime time) __attribute__((format(strftime, 2, 0)));
 #endif
 
  protected:


### PR DESCRIPTION
Fix issue #55 resolving not compiling due to septime namespace and include changes.