### PR TITLE
Improve Seesaw rotary stability on shared I2C

### DIFF
--- a/components/seesaw/__init__.py
+++ b/components/seesaw/__init__.py
@@ -21,10 +21,14 @@ Seesaw = seesaw_ns.class_("Seesaw", i2c.I2CDevice, cg.Component)
 SeesawGPIOPin = seesaw_ns.class_("SeesawGPIOPin", cg.GPIOPin)
 
 CONF_SEESAW = "seesaw"
+CONF_LOG_ERRORS = "log_errors"
+CONF_LOG_ERROR_INTERVAL = "log_error_interval_ms"
 
 CONFIG_SCHEMA = cv.COMPONENT_SCHEMA.extend(
     {
         cv.GenerateID(): cv.declare_id(Seesaw),
+        cv.Optional(CONF_LOG_ERRORS, default=False): cv.boolean,
+        cv.Optional(CONF_LOG_ERROR_INTERVAL, default="1s"): cv.positive_time_period_milliseconds,
     }
 ).extend(i2c.i2c_device_schema(0x49))
 
@@ -32,6 +36,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
+    cg.add(var.set_log_errors(config[CONF_LOG_ERRORS], config[CONF_LOG_ERROR_INTERVAL]))
 
 
 def validate_mode(value):
@@ -72,4 +77,3 @@ async def seesaw_pin_to_code(config):
     cg.add(var.set_inverted(config[CONF_INVERTED]))
     cg.add(var.set_flags(pins.gpio_flags_expr(config[CONF_MODE])))
     return var
-

--- a/components/seesaw/sensor/__init__.py
+++ b/components/seesaw/sensor/__init__.py
@@ -29,6 +29,7 @@ CONF_ADC = "adc"
 CONF_ENCODER = "encoder"
 CONF_TEMP = "temperature"
 CONF_TOUCH = "touch"
+CONF_POLL_INTERVAL_MS = "poll_interval_ms"
 
 CONFIG_SCHEMA = cv.typed_schema(
     {
@@ -54,6 +55,7 @@ CONFIG_SCHEMA = cv.typed_schema(
                 cv.Optional(CONF_NUMBER, default=0): cv.int_,
                 cv.Optional(CONF_MIN_VALUE): cv.int_,
                 cv.Optional(CONF_MAX_VALUE): cv.int_,
+                cv.Optional(CONF_POLL_INTERVAL_MS, default="20ms"): cv.positive_time_period_milliseconds,
             }
         ).extend(cv.COMPONENT_SCHEMA),
         CONF_TEMP: sensor.sensor_schema(
@@ -96,6 +98,6 @@ async def to_code(config):
             cg.add(var.set_min_value(config[CONF_MIN_VALUE]))
         if CONF_MAX_VALUE in config:
             cg.add(var.set_max_value(config[CONF_MAX_VALUE]))
+        cg.add(var.set_poll_interval_ms(config[CONF_POLL_INTERVAL_MS]))
     elif config[CONF_TYPE] == CONF_TOUCH:
         cg.add(var.set_channel(config[CONF_CHANNEL]))
-

--- a/components/seesaw/sensor/seesawrotaryencoder.cpp
+++ b/components/seesaw/sensor/seesawrotaryencoder.cpp
@@ -6,22 +6,61 @@ namespace seesaw {
 
 static const char *const TAG = "seesaw.encoder";
 
-void SeesawRotaryEncoder::setup() {
+void SeesawRotaryEncoder::setup()
+{
   ESP_LOGCONFIG(TAG, "Setting up Seesaw rotary encoder...");
   this->parent_->enable_encoder(this->number_);
-  this->publish_state(0);
+  int32_t position = 0;
+  if (!this->parent_->get_encoder_position(this->number_, &position))
+  {
+    position = 0;
+  }
+  if (position < this->min_value_)
+  {
+    position = this->min_value_;
+  }
+  if (position > this->max_value_)
+  {
+    position = this->max_value_;
+  }
+  this->value_ = position;
+  this->publish_state(this->value_);
 }
 
-void SeesawRotaryEncoder::loop() {
-  int32_t new_value = this->parent_->get_encoder_position(this->number_);
-  if (new_value < this->min_value_)
-    new_value = this->min_value_;
-  if (new_value > this->max_value_)
-    new_value = this->max_value_;
-  if (new_value == this->value_)
+/*
+ * Position-only encoder sampling path:
+ * read absolute position every poll interval and publish changes directly.
+ * This avoids dependence on DELTA reads, which can fail on some Seesaw setups.
+ */
+void SeesawRotaryEncoder::loop()
+{
+  const uint32_t now = millis();
+  if ((now - this->last_poll_ms_) < this->poll_interval_ms_)
+  {
     return;
-  this->value_ = new_value;
-  this->publish_state(new_value);
+  }
+  this->last_poll_ms_ = now;
+
+  int32_t position = 0;
+  if (!this->parent_->get_encoder_position(this->number_, &position))
+  {
+    return;
+  }
+
+  if (position < this->min_value_)
+  {
+    position = this->min_value_;
+  }
+  if (position > this->max_value_)
+  {
+    position = this->max_value_;
+  }
+  if (position == this->value_)
+  {
+    return;
+  }
+  this->value_ = position;
+  this->publish_state(this->value_);
 }
 
 }  // namespace seesaw

--- a/components/seesaw/sensor/seesawrotaryencoder.h
+++ b/components/seesaw/sensor/seesawrotaryencoder.h
@@ -16,6 +16,11 @@ class SeesawRotaryEncoder : public sensor::Sensor, public Component {
   void set_number(uint8_t number) { number_ = number; }
   void set_min_value(int32_t min_value) { this->min_value_ = min_value; }
   void set_max_value(int32_t max_value) { this->max_value_ = max_value; }
+  void set_poll_interval_ms(
+    uint32_t poll_interval_ms) // Minimum milliseconds between encoder reads.
+  {
+    this->poll_interval_ms_ = poll_interval_ms > 0 ? poll_interval_ms : 1u;
+  }
 
  protected:
   Seesaw *parent_;
@@ -23,6 +28,8 @@ class SeesawRotaryEncoder : public sensor::Sensor, public Component {
   int32_t value_{0};
   int32_t min_value_{INT32_MIN};
   int32_t max_value_{INT32_MAX};
+  uint32_t poll_interval_ms_{20}; // Minimum interval between I2C reads.
+  uint32_t last_poll_ms_{0}; // Timestamp of last encoder read.
 };
 
 }  // namespace seesaw


### PR DESCRIPTION
Add optional Seesaw error logging controls and rate limiting in codegen/runtime.

Switch rotary encoder path to explicit position reads with failure-aware API and configurable poll_interval_ms to reduce bus pressure.

Insert 250us register-write to data-read settle delay in Seesaw read transactions to align with Adafruit Arduino timing behavior and reduce POSITION read NACKs. 

Fixes #95 